### PR TITLE
feat: 로그인 미인증 접근 차단 필터 추가

### DIFF
--- a/src/main/java/team/omok/omok_mini_project/filter/LoginCheckFilter.java
+++ b/src/main/java/team/omok/omok_mini_project/filter/LoginCheckFilter.java
@@ -1,0 +1,39 @@
+package team.omok.omok_mini_project.filter;
+
+import team.omok.omok_mini_project.domain.vo.UserVO;
+
+import javax.servlet.*;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+
+/*
+  로그인 안 한 사용자가 /lobby, /room 등으로 바로 접근하는 걸 차단합니다.
+  세션 키: "loginUser" (LoginServlet에서 저장된)
+ */
+@WebFilter(urlPatterns = {"/lobby/*", "/room"})
+public class LoginCheckFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest req = (HttpServletRequest) request;
+        HttpServletResponse resp = (HttpServletResponse) response;
+
+
+        HttpSession session = req.getSession(false);
+        UserVO loginUser = (session == null) ? null : (UserVO) session.getAttribute("loginUser");
+
+        if (loginUser == null) {
+            // 로그인 안 되어있으면 로그인 페이지로
+            resp.sendRedirect(req.getContextPath() + "/login");
+            return;
+        }
+
+        // 로그인 되어있으면 통과
+        chain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
- 로그인하지 않은 사용자가 /lobby, /room 직접 접근하는 문제 해결
- LoginServlet에서 저장한 session 키 "loginUser" 기준으로 체크
- 미로그인 시 /login으로 redirect 처리
- 기존 로직 변경 없이 Filter 클래스 1개만 추가